### PR TITLE
As the user, I should be able to see details of pairing by putting in specific details url and the details persist on page load.

### DIFF
--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -53,10 +53,6 @@ const clearClicked = () => {
   setClicked('')
 }
 
-const updateError = () => {
-  setError(true);
-};
-
 const toggleSavePairing = (id) => {
   const newPairingsList = pairingList.map(pairing => {
     if(pairing.book.title === id) {
@@ -69,6 +65,7 @@ const toggleSavePairing = (id) => {
   })
   setPairingList(newPairingsList)
 }
+
 
   return (
     <div className="App">
@@ -100,9 +97,10 @@ const toggleSavePairing = (id) => {
           path="/details/:id"
           element={
             <Details
-              pairingList={pairingList}
               clearClicked={clearClicked}
               toggleSavePairing={toggleSavePairing}
+              pairingList={pairingList}
+              setClicked={setClicked}
             />
           }
         />

--- a/src/components/BookCard/BookCard.js
+++ b/src/components/BookCard/BookCard.js
@@ -4,7 +4,7 @@ import { useNavigate } from "react-router-dom"
 const BookCard = ({ drink, book }) => {
     const navigate = useNavigate()
     const handleClick = () => {
-      navigate(`/details/${book.title}`)
+      navigate(`/details/${book.title}  ${drink.id}`)
     }
     return (
         <button onClick={handleClick} className="book-card">

--- a/src/components/Details/Details.js
+++ b/src/components/Details/Details.js
@@ -4,16 +4,37 @@ import { getDrinkDetails } from "../../apiCalls/GETRequests"
 import { cleanRandomDrinkData } from "../../utilities/utilities"
 import { BsSuitHeartFill } from 'react-icons/bs'
 import Error from '../Error/Error'
+import PageNotFound from "../PageNotFound/PageNotFound"
 import './Details.css'
 
-const Details = ({ pairingList, clearClicked, toggleSavePairing }) => {
+const Details = ({ clearClicked, toggleSavePairing, pairingList, setClicked }) => {
     const [drinkDetails, setDrinkDetails] = useState({})
     const [isLoading, setIsLoading] = useState(true)
     const [drinkError, setDrinkError] = useState(false)
     const { id } = useParams()
-    const foundPairing = pairingList.find(pairing => pairing.book.title === id)
-    const drinkId = foundPairing.drink.id
-    const bookDetails = foundPairing.book
+    const drinkBook = id.split('  ')
+    const foundPairing = pairingList.find(pairing => pairing.book.title === drinkBook[0])
+    const drinkId = drinkBook[1]
+    let bookDetails
+    if(foundPairing) {
+        bookDetails = foundPairing.book
+    } else {
+        bookDetails = {
+            amazonProductUrl:'',
+            author: '',
+            bookImg: '',
+            nytReviewLink: '',
+            buyLinks: '',
+            description: '',
+            publisher: '',
+            title: '',
+            isSaved: '',
+        }
+    }
+
+
+
+
 
     useEffect(() => {
         clearClicked()
@@ -30,7 +51,10 @@ const Details = ({ pairingList, clearClicked, toggleSavePairing }) => {
                 setIsLoading(false)
             }
         }
-        createDrinkDetails(drinkId)
+        if(drinkId) {
+            createDrinkDetails(drinkId)
+        }
+
     }, [])
 
     const renderCheck = (detail) => {
@@ -42,6 +66,7 @@ const Details = ({ pairingList, clearClicked, toggleSavePairing }) => {
 
     return (
         <div className="full-page">
+            {foundPairing && <div className="full-page content-exists">
             {isLoading && <div className="is-loading-wrapper">Loading...</div>}
             {!isLoading && <div className="details-page">
                 <div className="save-button-wrapper">
@@ -95,6 +120,7 @@ const Details = ({ pairingList, clearClicked, toggleSavePairing }) => {
                     </div>
                     </div>
                 </div>
+            </div>}
             </div>}
         </div>
     )

--- a/src/components/FavBookCard/FavBookCard.js
+++ b/src/components/FavBookCard/FavBookCard.js
@@ -2,10 +2,10 @@ import './FavBookCard.css'
 import { BsTrash } from 'react-icons/bs'
 import { useNavigate } from "react-router-dom"
 
-const FavBookCard = ({ title, image, drink, toggleSavePairing }) => {
+const FavBookCard = ({ title, image, drink, toggleSavePairing, drinkId }) => {
     const navigate = useNavigate()
     const handleClick = () => {
-      navigate(`/details/${title}`)
+      navigate(`/details/${title}  ${drinkId}`)
     }
     return (
         <div className='fav-book-card'>

--- a/src/components/Favorites/Favorites.js
+++ b/src/components/Favorites/Favorites.js
@@ -12,6 +12,7 @@ const Favorites = ({ pairingList, toggleSavePairing, error }) => {
                 title={pairing.book.title}
                 image={pairing.book.bookImg}
                 drink={pairing.drink.name}
+                drinkId={pairing.drink.id}
                 toggleSavePairing={toggleSavePairing}
                 />
             )

--- a/src/utilities/utilities.js
+++ b/src/utilities/utilities.js
@@ -15,7 +15,6 @@ export const cleanBookListData = (data) => {
                       } = book
                     //possible put a GET request for drink to pair with book here.... is this possible? I could then create a drink key that would house the drink information....
                     const cleanedBook = {
-                        id: Date.now(),
                         amazonProductUrl: amazon_product_url,
                         author,
                         bookImg: book_image,
@@ -24,7 +23,6 @@ export const cleanBookListData = (data) => {
                         description,
                         publisher,
                         title,
-
                     }
                     cleanBookList.push(cleanedBook)
                 }


### PR DESCRIPTION
# Description

This PR redoes the functionality on the details page for retrieving details so that the details can persist on page load and will show up if the user uses a specific details URL.

# Fixes # (issue)
#27 
# Type of change

- [x]  Bug fix (non-breaking change which fixes an issue)
 
- [ ]  New feature (non-breaking change which adds functionality)

- [x]  Breaking change (fix or feature that would cause existing functionality not to work as expected)

- [ ] This change requires a documentation update

-  [ ] Styling

- [ ] Refactor

- [ ] Testing

# Where were the changes?
Details.js, App.js, BookCard.js, FavBookCard.js

# How Has This Been Tested?
Tested numerous times on the DOM/eternal API backend servers and using console logs to ensure it is still functioning as before and confirmed this is the case.

# Checklist:

- [x]  My code follows the style guidelines of this project
- [x]  I have performed a self-review of my code
- [ ]  I have commented my code, particularly in hard-to-understand areas (if applicable)
- [ ]  I have made corresponding changes to the documentation (if applicable)
- [x]  My changes generate no new warnings
- [ ]  New and existing unit tests pass locally with my changes (if applicable)
